### PR TITLE
Upgrade to cmdlang.0.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 #           janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
       - name: Install dependencies
-        run: opam install . --deps-only --with-doc --with-test
+        run: opam install . --deps-only --with-doc --with-test --with-dev-setup
 
       - name: Build
         run: opam exec -- dune build @all @lint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,23 +1,15 @@
-## 0.0.9 (unreleased)
-
-### Added
+## 0.0.9 (2024-09-07)
 
 ### Changed
 
-- Upgrade to `commandlang.0.0.2`.
+- Upgrade to `cmdlang.0.0.4`.
 - Split test package & use `expect_test_helpers_base`.
-
-### Deprecated
-
-### Fixed
-
-### Removed
 
 ## 0.0.8 (2024-08-19)
 
 ### Changed
 
-- Switch to using `commandlang` for commands.
+- Switch to using `cmdlang` for commands.
 
 ## 0.0.7 (2024-07-26)
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 
 .PHONY: deps
 deps:
-	opam install . --deps-only --with-doc --with-test
+	opam install . --deps-only --with-doc --with-test --with-dev-setup
 
 .PHONY: doc
 doc:

--- a/bin/dune
+++ b/bin/dune
@@ -3,6 +3,6 @@
  (public_name super-master-mind)
  (package super-master-mind)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries commandlang-to-cmdliner super-master-mind)
+ (libraries cmdlang-to-cmdliner super-master-mind)
  (instrumentation
   (backend bisect_ppx)))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,5 +1,5 @@
 let () =
-  Commandlang_to_cmdliner.run
+  Cmdlang_to_cmdliner.run
     Super_master_mind.main
     ~name:"super-master-mind"
     ~version:"%%VERSION%%"

--- a/dune-project
+++ b/dune-project
@@ -25,16 +25,12 @@
    (and
     (>= v0.17)
     (< v0.18)))
-  (bisect_ppx
-   (and
-    :dev
-    (>= 2.8.3)))
+  (cmdlang
+   (>= 0.0.4))
+  (cmdlang-to-cmdliner
+   (>= 0.0.4))
   (cmdliner
    (= 1.3.0))
-  (commandlang
-   (>= 0.0.2))
-  (commandlang-to-cmdliner
-   (>= 0.0.2))
   (domainslib
    (>= 0.5))
   (nonempty-list
@@ -69,11 +65,6 @@
    (and
     (>= v0.17)
     (< v0.18)))
-  (ppx_js_style
-   (and
-    :dev
-    (>= v0.17)
-    (< v0.18)))
   (ppx_let
    (and
     (>= v0.17)
@@ -101,20 +92,24 @@
  (depends
   (ocaml
    (>= 5.2))
+  (ocamlformat
+   (and
+    :with-dev-setup
+    (= 0.26.2)))
   (base
    (and
     (>= v0.17)
     (< v0.18)))
   (bisect_ppx
    (and
-    :dev
+    :with-dev-setup
     (>= 2.8.3)))
+  (cmdlang
+   (>= 0.0.4))
+  (cmdlang-to-cmdliner
+   (>= 0.0.4))
   (cmdliner
    (= 1.3.0))
-  (commandlang
-   (>= 0.0.2))
-  (commandlang-to-cmdliner
-   (>= 0.0.2))
   (domainslib
    (>= 0.5))
   (expect_test_helpers_core
@@ -159,7 +154,7 @@
     (< v0.18)))
   (ppx_js_style
    (and
-    :dev
+    :with-dev-setup
     (>= v0.17)
     (< v0.18)))
   (ppx_let

--- a/lib/super_master_mind/src/dune
+++ b/lib/super_master_mind/src/dune
@@ -12,10 +12,10 @@
   -open
   Stdio
   -open
-  Commandlang)
+  Cmdlang)
  (libraries
   base
-  commandlang
+  cmdlang
   domainslib
   nonempty-list
   parsexp

--- a/super-master-mind-tests.opam
+++ b/super-master-mind-tests.opam
@@ -10,11 +10,12 @@ bug-reports: "https://github.com/mbarbin/super-master-mind/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
   "base" {>= "v0.17" & < "v0.18"}
-  "bisect_ppx" {dev & >= "2.8.3"}
+  "bisect_ppx" {with-dev-setup & >= "2.8.3"}
+  "cmdlang" {>= "0.0.4"}
+  "cmdlang-to-cmdliner" {>= "0.0.4"}
   "cmdliner" {= "1.3.0"}
-  "commandlang" {>= "0.0.2"}
-  "commandlang-to-cmdliner" {>= "0.0.2"}
   "domainslib" {>= "0.5"}
   "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
   "nonempty-list" {>= "v0.17" & < "v0.18"}
@@ -26,7 +27,7 @@ depends: [
   "ppx_expect" {>= "v0.17" & < "v0.18"}
   "ppx_hash" {>= "v0.17" & < "v0.18"}
   "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
+  "ppx_js_style" {with-dev-setup & >= "v0.17" & < "v0.18"}
   "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}

--- a/super-master-mind.opam
+++ b/super-master-mind.opam
@@ -11,10 +11,9 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
   "base" {>= "v0.17" & < "v0.18"}
-  "bisect_ppx" {dev & >= "2.8.3"}
+  "cmdlang" {>= "0.0.4"}
+  "cmdlang-to-cmdliner" {>= "0.0.4"}
   "cmdliner" {= "1.3.0"}
-  "commandlang" {>= "0.0.2"}
-  "commandlang-to-cmdliner" {>= "0.0.2"}
   "domainslib" {>= "0.5"}
   "nonempty-list" {>= "v0.17" & < "v0.18"}
   "ocaml-embed-file" {>= "v0.17" & < "v0.18"}
@@ -24,7 +23,6 @@ depends: [
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}
   "ppx_hash" {>= "v0.17" & < "v0.18"}
   "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_js_style" {dev & >= "v0.17" & < "v0.18"}
   "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (cram
+ (package super-master-mind-tests)
  (deps
   (package super-master-mind)
   %{bin:super-master-mind}))


### PR DESCRIPTION
### Changed

- Upgrade to `cmdlang.0.0.4`.
- Split test package & use `expect_test_helpers_base`.
