### PR TITLE
Remove all of _build instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build and Run tests
         run: |
-          rm -rf _build/default/
+          rm -rf _build/
           mkdir $BISECT_DIR
           dune build @all @runtest --force --instrument-with bisect_ppx
         env:

--- a/dune-workspace.5.4
+++ b/dune-workspace.5.4
@@ -3,7 +3,7 @@
 (pkg enabled)
 
 (lock_dir
- (repositories overlay upstream alpha mbarbin)
+ (repositories overlay relocatable upstream alpha mbarbin)
  (constraints
   (ocaml
    (= 5.4.1))))
@@ -15,3 +15,8 @@
 (repository
  (name alpha)
  (url "git+https://github.com/kit-ty-kate/opam-alpha-repository.git"))
+
+(repository
+ (name relocatable)
+ (url
+  "git+https://github.com/ocaml-dune/opam-repository-relocatable.git#relocatable"))


### PR DESCRIPTION
- This is an attempt at avoiding I/O error in the new dune.

The motivation for selectively deleting _build/default was based on working around some other bugs and this may not be required anymore.

Note:
- [ ] I'm experimenting with the change and if it works I'll add a coupe links to relevant context information.