### PR TITLE
Keep _build to fix I/O error with new dune

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Build and Run tests
         run: |
-          rm -rf _build/default/
           mkdir $BISECT_DIR
           dune build @all @runtest --force --instrument-with bisect_ppx
         env:


### PR DESCRIPTION
The removal of `_build/default/` is causing I/O error with new dune.
Attempt to remove that step entirely to try and trigger some issues. If none we can keep it like that.